### PR TITLE
add codespaces and dev container button

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ description: A complete event-driven application that includes everything you ne
 
 # Event Driven Application with Azure Service Bus on Azure Spring Apps
 
+[![Open in GitHub Codespaces](https://img.shields.io/static/v1?style=for-the-badge&label=GitHub+Codespaces&message=Open&color=brightgreen&logo=github)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=605391801&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=WestUs2)
+[![Open in Remote - Containers](https://img.shields.io/static/v1?style=for-the-badge&label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/azure-samples/ASA-Samples-Event-Driven-Application)
+
 A complete event-driven application that includes everything you need to build, deploy, and monitor an Azure solution. This application uses the Azure Developer CLI (azd) to get you up and running on Azure quickly, Java for the application, Azure Service Bus for the message queue, Azure Key Vault for storing application secrets and Azure Monitor for monitoring and logging. It includes application code, tools, and pipelines that serve as a foundation from which you can build upon and customize when creating your own solutions.
 
 Let's jump in and get the event-driven app up and running in Azure. When you are finished, you will have a fully functional event driven app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,9 +18,10 @@ param relativePath string
 param logAnalyticsName string = ''
 param applicationInsightsName string = ''
 param applicationInsightsDashboardName string = ''
+param utcValue string = utcNow()
 
 var abbrs = loadJsonContent('./abbreviations.json')
-var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location, utcValue))
 var keyVaultName = '${abbrs.keyVaultVaults}${resourceToken}'
 var serviceBusNamespaceName = '${environmentName}-${abbrs.serviceBusNamespaces}${resourceToken}'
 var asaInstanceName = '${environmentName}-${abbrs.springApps}${resourceToken}'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,10 +18,9 @@ param relativePath string
 param logAnalyticsName string = ''
 param applicationInsightsName string = ''
 param applicationInsightsDashboardName string = ''
-param utcValue string = utcNow()
 
 var abbrs = loadJsonContent('./abbreviations.json')
-var resourceToken = toLower(uniqueString(subscription().id, environmentName, location, utcValue))
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var keyVaultName = '${abbrs.keyVaultVaults}${resourceToken}'
 var serviceBusNamespaceName = '${environmentName}-${abbrs.serviceBusNamespaces}${resourceToken}'
 var asaInstanceName = '${environmentName}-${abbrs.springApps}${resourceToken}'


### PR DESCRIPTION
This pr includes the following changes:
1. add buttons for codespaces and dev container in README
2. update the resource token for azure resource name by adding the parameter of time, to resolve that Key Vault names may be duplicate for the same azd env. We need to take extra concern for key vault due to that it can run into error when provisioning kv with the same name as a previous soft-deleted one.