### PR TITLE
fix wrong env name

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   cloud:
     azure:
       servicebus:
-        connection-string: ${SERVICE-BUS-CONNECTION-STRING}
+        connection-string: ${SERVICE_BUS_CONNECTION_STRING}
     stream:
       function:
         definition: process


### PR DESCRIPTION
As subject, this pr is to fix the wrong env name of sb connection string after we remove key vault.